### PR TITLE
Small free Point bugfix and a couple tweaks:

### DIFF
--- a/source/Connection.cpp
+++ b/source/Connection.cpp
@@ -273,8 +273,11 @@ void Connection::setKinematics(double *r_in, double *rd_in)
 
 // pass the latest states to the connection ()
 moordyn::error_id Connection::setState(const double X[6],
-                                       const double PARAM_UNUSED time)
+                                       const double time)
 {
+	// store current time
+	t = time;
+	
 	// the kinematics should only be set with this function of it's an independent/free connection
 	if (type != FREE) // "connect" type
 	{

--- a/source/Connection.hpp
+++ b/source/Connection.hpp
@@ -35,10 +35,11 @@ class Waves;
  * how those points are moving. There are 3 basic types of connections:
  *
  *  - Fixed: The point is indeed fixed, either to a unmovable point (i.e. an
- *           anchor) or to another moving body
- *  - Free: The point freely moves, like the line endpoint is not attached to
- *          anything. This will be the connection generated when a line is
- *          failing
+ *           anchor) or to a Body
+ *  - Free: The point freely moves, with its own translation degrees of freedom,
+ *          to provide a connection point between multiple mooring lines or an
+ *          unconnected termination point of a Line, which could have a clump
+ *          weight or float via the point's mass and volume parameters 
  *  - Coupled: The connection position and velocity is externally imposed
  */
 class Connection : public LogUser

--- a/source/Line.cpp
+++ b/source/Line.cpp
@@ -423,7 +423,7 @@ double Line::getNodeTen(int i)
 {
 	double NodeTen = 0.0;
 	if ((i==0) || (i==N))
-		NodeTen = (Fnet[i] + vec(0.0, 0.0, M[i](0, 0) * (-env->g))).norm();
+		NodeTen = (Fnet[i] + vec(0.0, 0.0, M[i](0, 0) * (-env->g))).norm();  // <<< update to use W
 	else 
 	{
 		// take average of tension in adjacent segments 
@@ -1291,6 +1291,14 @@ void Line::Output(double time)
 			if (channels.find("t") != string::npos) {
 				for (int i=0; i<N; i++)  {
 					*outfile << T[i].norm() << "\t ";
+					// >>> preparation below for switching to outputs at nodes <<<
+					// note that tension of end nodes will need weight and buoyancy adjustment 
+					//if (i==0)
+					//      *outfile << (T[i] + W[i]).norm() << "\t ";
+					//else if (i==N)
+					//      *outfile << (T[i] - W[i]).norm() << "\t ";
+					//else
+					//	*outfile << T[i].norm() << "\t ";
 				}
 			}
 			// output internal damping force?

--- a/source/MoorDyn2.cpp
+++ b/source/MoorDyn2.cpp
@@ -485,8 +485,11 @@ moordyn::error_id moordyn::MoorDyn::Step(const double *x,
 
 	if (dt <= 0)
 	{
-		// Nothing to do, just recover the forces
-		return GetForces(f);
+		// Nothing to do, just recover the forces if there are coupled DOFs
+		if (NCoupedDOF())
+			return GetForces(f);
+		else
+			return MOORDYN_SUCCESS;
 	}
 
 	if (NCoupedDOF() && (!x || !xd || !f))
@@ -575,7 +578,11 @@ moordyn::error_id moordyn::MoorDyn::Step(const double *x,
 	if (err != MOORDYN_SUCCESS)
 		return err;
 
-	return GetForces(f);
+	// recover the forces if there are coupled DOFs
+	if (NCoupedDOF())
+		return GetForces(f);
+	else
+		return MOORDYN_SUCCESS;
 }
 
 moordyn::error_id moordyn::MoorDyn::ReadInFile()


### PR DESCRIPTION
- Restored deleted t=time in Connection.setState to restore proper
  function of free connection points. Corrected docstring.
- Added a few notes for myself related to Line tension to do items.
- Adjusted the MoorDyn Step function to avoid warning messages when
  called with zero coupled objects (which can be normal).